### PR TITLE
Update for IntelliJ 14

### DIFF
--- a/Global/JetBrains.gitignore
+++ b/Global/JetBrains.gitignore
@@ -1,15 +1,11 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
 
-*.iml
+# Based on https://intellij-support.jetbrains.com/entries/23393067
 
-## Directory-based project format:
-.idea/
-# if you remove the above rule, at least ignore the following:
-
-# User-specific stuff:
-# .idea/workspace.xml
-# .idea/tasks.xml
-# .idea/dictionaries
+# IntelliJ 14
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
 
 # Sensitive or high-churn files:
 # .idea/dataSources.ids
@@ -25,7 +21,7 @@
 # Mongo Explorer plugin:
 # .idea/mongoSettings.xml
 
-## File-based project format:
+## IntelliJ 13 and below file-based project format:
 *.ipr
 *.iws
 


### PR DESCRIPTION
.idea file shouldn't be ignored in IntelliJ 14. File now follows official JetBrains recommendations.